### PR TITLE
Refactor client_name handling in mlfi_connect

### DIFF
--- a/AMAVISD-MILTER.md
+++ b/AMAVISD-MILTER.md
@@ -169,6 +169,7 @@ Then (re)start amavisd daemon.
 
 To the sendmail.mc file add the following entries:
 
+    define(`confMILTER_MACROS_CONNECT', confMILTER_MACROS_CONNECT`, {client_resolve}')
     define(`confMILTER_MACROS_ENVFROM', confMILTER_MACROS_ENVFROM`, r, b')
     INPUT_MAIL_FILTER(`amavisd-milter',
         `S=local:/var/amavis/amavisd-milter.sock,

--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ This is the CHANGELOG for amavisd-milter.
 	use the hostname.
 
 	Signed-off-by: Florian Pritz <bluewind@xinu.at>
+	Modified-by: Petr Rehor <rx@rx.cz>
 
 20190116:
 	Removed obsoleted file amavisd-milter.spec.

--- a/amavisd-milter/amavisd-milter.8
+++ b/amavisd-milter/amavisd-milter.8
@@ -260,6 +260,8 @@ Then (re)start amavisd daemon.
 .Ss Configuring sendmail
 To the sendmail.mc file add the following entries:
 .Bd -literal -offset indent
+define(`confMILTER_MACROS_CONNECT',
+	confMILTER_MACROS_CONNECT`, {client_resolve}')
 define(`confMILTER_MACROS_ENVFROM',
 	confMILTER_MACROS_ENVFROM`, r, b')
 INPUT_MAIL_FILTER(`amavisd-milter',

--- a/amavisd-milter/amavisd-milter.h
+++ b/amavisd-milter/amavisd-milter.h
@@ -55,7 +55,8 @@ struct mlfiCtx {
     char       *mlfi_daemon_name;	/* sendmail daemon name */
     char       *mlfi_hostname;		/* sendmail hostname */
     char       *mlfi_client_addr;	/* remote host address */
-    char       *mlfi_client_host;	/* remote host name */
+    char       *mlfi_client_host;	/* remote host name or address */
+    char       *mlfi_client_name;	/* remote host name */
     char       *mlfi_helo;		/* remote host helo */
     char       *mlfi_protocol;		/* communication protocol */
     char       *mlfi_qid;		/* queue id */

--- a/amavisd-milter/mlfi.c
+++ b/amavisd-milter/mlfi.c
@@ -338,7 +338,7 @@ mlfi_connect(SMFICTX *ctx, char *client_host, _SOCK_ADDR * hostaddr)
     mlfi->mlfi_amasd = -1;
 
     /* Save connection informations */
-    if ((mlfi->mlfi_client_host = strdup(client_name)) == NULL) {
+    if ((mlfi->mlfi_client_host = strdup(client_host)) == NULL) {
 	logmsg(LOG_ERR, "%s: could not allocate memory", client_host);
 	 mlfi_setreply_tempfail(ctx);
 	 return SMFIS_TEMPFAIL;

--- a/amavisd-milter/mlfi.c
+++ b/amavisd-milter/mlfi.c
@@ -338,22 +338,33 @@ mlfi_connect(SMFICTX *ctx, char *client_host, _SOCK_ADDR * hostaddr)
     (void) memset(mlfi, '\0', sizeof(*mlfi));
     mlfi->mlfi_amasd = -1;
 
-    /* Save connection informations */
+    /* Save client hostname (Reverse DNS or IP addresss in square bracket) */
     if ((mlfi->mlfi_client_host = strdup(client_host)) == NULL) {
 	logmsg(LOG_ERR, "%s: could not allocate memory", client_host);
 	 mlfi_setreply_tempfail(ctx);
 	 return SMFIS_TEMPFAIL;
     }
+
+    /*
+     * Save client Forward-confirmed reverse DNS name (FCrDNS) or "unknown"
+     * for Spamassassin's RDNS_NONE check.  In the {client_name} macro,
+     * Sendmail sends a reverse DNS name or IP address in square brackets
+     * unless the client has a reverse DNS.  Postfix sends a FCrDNS or
+     * "unknown".
+     */
     client_name = smfi_getsymval(ctx, "{client_name}");
     if (client_name == NULL || *client_name == '\0') {
+	/* Use client_host if macro {client_name} is not set */
 	client_name = client_host;
     }
     if (*client_name == '[') {
+	/* Client hostname contains IP address in square brackets */
 	client_name = "unknown";
     }
     client_resolve = smfi_getsymval(ctx, "{client_resolve}");
     if (client_resolve != NULL && strcmp(client_resolve, "OK") != 0) {
-       client_name = "unknown";
+	/* If client_resolve is not "OK", the client_name is not FCrDNS */
+	client_name = "unknown";
     }
     logqidmsg(mlfi, LOG_DEBUG, "client name: %s", client_name);
     if ((mlfi->mlfi_client_name = strdup(client_name)) == NULL) {
@@ -361,6 +372,8 @@ mlfi_connect(SMFICTX *ctx, char *client_host, _SOCK_ADDR * hostaddr)
         mlfi_setreply_tempfail(ctx);
         return SMFIS_TEMPFAIL;
     }
+
+    /* Save client IP address */
     addr = NULL;
     if (hostaddr != NULL) {
 	switch(hostaddr->sa_family) {
@@ -405,6 +418,8 @@ mlfi_connect(SMFICTX *ctx, char *client_host, _SOCK_ADDR * hostaddr)
 		mlfi->mlfi_client_addr);
 	}
     }
+
+    /* Save daemon name */
     if ((daemon_name = smfi_getsymval(ctx, "{daemon_name}")) != NULL) {
 	logqidmsg(mlfi, LOG_INFO, "Daemon name: %s", daemon_name);
 	if ((mlfi->mlfi_daemon_name = strdup(daemon_name)) == NULL) {
@@ -425,7 +440,7 @@ mlfi_connect(SMFICTX *ctx, char *client_host, _SOCK_ADDR * hostaddr)
 	return SMFIS_TEMPFAIL;
     }
 
-    /* Save the private data */
+    /* Save private data */
     if (smfi_setpriv(ctx, mlfi) != MI_SUCCESS) {
 	logqidmsg(mlfi, LOG_ERR, "could not set milter context");
 	mlfi_setreply_tempfail(ctx);

--- a/amavisd-milter/mlfi.c
+++ b/amavisd-milter/mlfi.c
@@ -314,6 +314,7 @@ mlfi_connect(SMFICTX *ctx, char *client_host, _SOCK_ADDR * hostaddr)
     const void *addr;
     const char *prefix;
     const char *client_name;
+    const char *client_resolve;
     const char *daemon_name;
     const char *hostname;
     int		len, plen;
@@ -349,6 +350,10 @@ mlfi_connect(SMFICTX *ctx, char *client_host, _SOCK_ADDR * hostaddr)
     }
     if (*client_name == '[') {
 	client_name = "unknown";
+    }
+    client_resolve = smfi_getsymval(ctx, "{client_resolve}");
+    if (client_resolve != NULL && strcmp(client_resolve, "OK") != 0) {
+       client_name = "unknown";
     }
     logqidmsg(mlfi, LOG_DEBUG, "client name: %s", client_name);
     if ((mlfi->mlfi_client_name = strdup(client_name)) == NULL) {


### PR DESCRIPTION
Spamassassin's RDNS_NONE check requires in the synthesized Received: header Forward-confirmed reverse DNS (FCrDNS) client name or "unknown" if the FCrDNS is not available.

Sendmail sends the reverse DNS or IP address in square brackets both in the client_host argument and  the {client_name} macro. If the client name is FCrDNS, macro {client_reverse} is set to `OK`, otherwise to `FORGED`, `TEMP` or `FAIL`. 

Postfix sends a FCrDNS or "unknown" using the {client_name} macro.

Related-to: #1, #3

Signed-off-by: Petr Řehoř <rx@rx.cz>