### PR TITLE
The milter socket is created before amavisd-milter is daemonized

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,13 @@
 This is the CHANGELOG for amavisd-milter.
 
+20190121:
+	The milter socket is created before amavisd-milter is daemonized.
+	This allows to return an error in case of impossibility to create
+	the milter socket and package maintainers can adjust milter socket
+	permissions immediatelly after the main process exits.
+
+	Thanks to: Matus Uhlar
+
 20190119:
 	The Spamassassin's RDNS_NONE check tests if the rdns field in
 	the Received header is empty or "unknown".  Postfix sets

--- a/amavisd-milter/main.c
+++ b/amavisd-milter/main.c
@@ -377,17 +377,6 @@ main(int argc, char *argv[])
 	}
     }
 
-    /* Run in the background */
-    if (daemonize) {
-	if (daemon(1, 1) != -1) {
-	    daemonized = 1;
-	} else {
-	    logmsg(LOG_ERR, "could not fork daemon process: %s",
-		strerror(errno));
-	    exit(EX_OSERR);
-	}
-    }
-
     /* Connect to milter socket */
 #ifdef HAVE_SMFI_SETBACKLOG
     if (mlfi_socket_backlog > 0) {
@@ -403,6 +392,17 @@ main(int argc, char *argv[])
         exit(EX_SOFTWARE);
     }
 #endif
+
+    /* Run in the background */
+    if (daemonize) {
+	if (daemon(1, 1) != -1) {
+	    daemonized = 1;
+	} else {
+	    logmsg(LOG_ERR, "could not fork daemon process: %s",
+		strerror(errno));
+	    exit(EX_OSERR);
+	}
+    }
 
     /* Greetings message */
     logmsg(LOG_WARNING, "starting %s %s on socket %s", progname, VERSION,


### PR DESCRIPTION
This allows to return an error in case of impossibility to create the milter socket and package maintainers can adjust milter socket permissions immediatelly after the main process exits.

Signed-off-by: Petr Řehoř <rx@rx.cz>