### PR TITLE
amavisd-milter-1.7.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,20 @@
 This is the CHANGELOG for amavisd-milter.
 
+20190227:
+        amavisd-milter-1.7.0:
+
+        amavisd-milter has been moved from SourceForge to to GitHub.
+
+        New features:
+        - Fork after initializing milter socket.
+        - Use client_name if available instead of hostname passed to xxfi_connect.
+        - Generate amamvisd-milter.8 from AMAVISD-MILTER.md.
+
+        Bug and compatibility fixies:
+        - Fixed compiler warnings.
+        - Converted indentation to spaces only.
+        - Removed obsoleted file amavisd-milter.spec.
+
 20190203:
         Generate amamvisd-milter.8 from AMAVISD-MILTER.md.
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ amavisd-milter is a milter interface for the [amavis](https://www.amavis.org) sp
 
 The simplest way to compile amavisd-milter:
 ```
-curl -L -o amavisd-milter-1.6.1.tar.gz https://github.com/prehor/amavisd-milter/archive/1.6.1.tar.gz
-tar xfz amavisd-milter-1.6.1.tar.gz
-cd amavisd-milter-1.6.1
-sh autoconf.sh.in
+curl -L https://github.com/prehor/amavisd-milter/releases/download/1.7.0/amavisd-milter-1.7.0.tar.gz | tar xfz -
+cd amavisd-milter-1.7.0
 ./configure
 make all
 make install

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,10 @@
 AC_INIT([amavisd-milter],
-  m4_esyscmd([[ -n "${AMAVISD_MILTER_VERSION}" ] && echo -n "${AMAVISD_MILTER_VERSION}" || echo -n "dev-$(TZ=UTC date +%Y%m%d-%H%M%S)"]))
+  m4_esyscmd([
+    [ -n "${AMAVISD_MILTER_VERSION}" ] &&
+    /bin/echo -n "${AMAVISD_MILTER_VERSION}" ||
+    /bin/echo -n "dev-$(TZ=UTC date +%Y%m%d)"
+  ])dnl
+)
 AC_PREREQ(2.62)
 
 AC_CONFIG_SRCDIR(aclocal/acinclude.m4)


### PR DESCRIPTION
amavisd-milter has been moved from SourceForge to to GitHub.

New features:
- Fork after initializing milter socket.
- Use `client_name` if available instead of hostname passed to `xxfi_connect`.
- Generate amamvisd-milter.8 from AMAVISD-MILTER.md.

Bug and compatibility fixies:
- Fixed compiler warnings.
- Converted indentation to spaces only.
- Removed obsoleted file amavisd-milter.spec.

Signed-off-by: Petr Řehoř <rx@rx.cz>