### PR TITLE
amavisd-milter-1.7.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 This is the CHANGELOG for amavisd-milter.
 
+20200906:
+        amavisd-milter-1.7.1:
+
+        Bug and compatibility fixies:
+        - An empty sender must always be enclosed in angle brackets.
+
 20190227:
         amavisd-milter-1.7.0:
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ amavisd-milter is a milter interface for the [amavis](https://www.amavis.org) sp
 
 The simplest way to compile amavisd-milter:
 ```
-curl -L https://github.com/prehor/amavisd-milter/releases/download/1.7.0/amavisd-milter-1.7.0.tar.gz | tar xfz -
-cd amavisd-milter-1.7.0
+curl -L https://github.com/prehor/amavisd-milter/releases/download/1.7.1/amavisd-milter-1.7.1.tar.gz | tar xfz -
+cd amavisd-milter-1.7.1
 ./configure
 make all
 make install


### PR DESCRIPTION
Bug and compatibility fixies:
- An empty sender must always be enclosed in angle brackets.

Signed-off-by: Petr Řehoř <rx@rx.cz>