### PR TITLE
Fix typo in log message

### DIFF
--- a/amavisd-milter/mlfi.c
+++ b/amavisd-milter/mlfi.c
@@ -219,7 +219,7 @@ mlfi_cleanup_message(struct mlfiCtx *mlfi)
             }
             if (fts_close(fts) != 0) {
                 logqidmsg(mlfi, LOG_WARNING,
-                    "could not close file hirerachy %s: %s",
+                    "could not close file hierarchy %s: %s",
                     mlfi->mlfi_wrkdir, strerror(errno));
             }
         }


### PR DESCRIPTION
"hirerachy" → "hierarchy"